### PR TITLE
Split apart leader conditions and permission conditions

### DIFF
--- a/concord/actions/state_changes.py
+++ b/concord/actions/state_changes.py
@@ -385,7 +385,10 @@ def foundational_changes():
         'concord.actions.state_changes.EnableFoundationalPermissionStateChange',
         'concord.actions.state_changes.DisableFoundationalPermissionStateChange',
         'concord.actions.state_changes.EnableGoverningPermissionStateChange',
-        'concord.actions.state_changes.DisableGoverningPermissionStateChange'
+        'concord.actions.state_changes.DisableGoverningPermissionStateChange',
+        'concord.conditionals.state_changes.AddLeaderConditionStateChange',
+        'concord.conditionals.state_changes.RemoveLeaderConditionStateChange',
+        'concord.conditionals.state_changes.ChangeLeaderCondition'
     ]
 
 

--- a/concord/conditionals/client.py
+++ b/concord/conditionals/client.py
@@ -131,6 +131,12 @@ class BaseConditionalClient(BaseClient):
         return
         # FIXME: should probably return empty list, but that breaks a bunch of tests, so need to refactor
 
+
+class PermissionConditionalClient(BaseConditionalClient):
+    '''
+    Target is always a Permission.
+    '''
+
     # Stage changes
 
     # FIXME: It would be nice to be able to pass in the ConditionTemplate, and/or to be able to pass in
@@ -152,11 +158,6 @@ class BaseConditionalClient(BaseClient):
         change = sc.RemoveConditionStateChange(condition_pk=condition.pk)
         return self.create_and_take_action(change)
 
-
-class PermissionConditionalClient(BaseConditionalClient):
-    '''
-    Target is always a Permission.
-    '''
 
 class CommunityConditionalClient(BaseConditionalClient):
     '''
@@ -206,6 +207,23 @@ class CommunityConditionalClient(BaseConditionalClient):
             return self.get_condition_info(condition_template)
 
     # State Changes
+
+    def add_condition(self, *, condition_type: str, target_type: str, permission_data: Dict = None, 
+            condition_data: Dict = None):
+        change = sc.AddLeaderConditionStateChange(condition_type=condition_type,
+            permission_data=permission_data, condition_data=condition_data, target_type=target_type)
+        return self.create_and_take_action(change)
+
+    def change_condition(self, *, condition_pk: int, permission_data: Dict = None, 
+        condition_data: Dict = None) -> Tuple[int, Any]:
+        # FIXME: this unnecessarily requires target (a permission) to be set 
+        change = sc.ChangeLeaderConditionStateChange(condition_pk=condition_pk,
+            permission_data=permission_data, condition_data=condition_data)
+        return self.create_and_take_action(change)
+
+    def remove_condition(self, *, condition: Model) -> Tuple[int, Any]:
+        change = sc.RemoveLeaderConditionStateChange(condition_pk=condition.pk)
+        return self.create_and_take_action(change)
 
     def add_condition_to_governors(self, *, condition_type: str, permission_data: Dict = None, 
             condition_data: Dict = None) -> Tuple[int, Any]:

--- a/concord/conditionals/state_changes.py
+++ b/concord/conditionals/state_changes.py
@@ -26,7 +26,7 @@ class AddConditionStateChange(BaseStateChange):
     @classmethod
     def get_settable_classes(cls):
         from concord.permission_resources.models import PermissionsItem
-        return cls.get_community_models() + [PermissionsItem]
+        return [PermissionsItem]
 
     def description_present_tense(self):
         return "add condition %s" % (self.condition_type)  
@@ -63,7 +63,7 @@ class RemoveConditionStateChange(BaseStateChange):
     @classmethod
     def get_settable_classes(cls):
         from concord.permission_resources.models import PermissionsItem
-        return cls.get_community_models() + [PermissionsItem]
+        return [PermissionsItem]
 
     def description_present_tense(self):
         return "remove condition with id %s" % (self.condition_pk)  
@@ -95,7 +95,7 @@ class ChangeConditionStateChange(BaseStateChange):
     @classmethod
     def get_settable_classes(cls):
         from concord.permission_resources.models import PermissionsItem
-        return cls.get_community_models() + [PermissionsItem] 
+        return [PermissionsItem] 
 
     def description_present_tense(self):
         return "change condition %s" % (self.condition_pk)  
@@ -131,6 +131,28 @@ class ChangeConditionStateChange(BaseStateChange):
         template.condition_data.update_permission_data(self.permission_data)
         template.save()
         return template
+
+
+class AddLeaderConditionStateChange(AddConditionStateChange):
+
+    @classmethod
+    def get_settable_classes(cls):
+        return cls.get_community_models()
+
+
+class RemoveLeaderConditionStateChange(RemoveConditionStateChange):
+
+    @classmethod
+    def get_settable_classes(cls):
+        return cls.get_community_models()
+
+
+class ChangeLeaderCondition(ChangeConditionStateChange):
+
+    @classmethod
+    def get_settable_classes(cls):
+        return cls.get_community_models()
+
 
 
 ####################################


### PR DESCRIPTION
Leader conditions need to be considered foundational changes and protected, and right now the way we track foundational changes is by listing the state change class, so they need to be separate state changes