### PR TITLE
Remove AbstractItem, AbstractResource

### DIFF
--- a/concord/resources/models.py
+++ b/concord/resources/models.py
@@ -36,13 +36,16 @@ class CommentCatcher(PermissionedModel):
         return f"Comment catcher for action {self.action}"
 
 
-class AbstractResource(PermissionedModel):
-    """Abstract Resource model contains basic functionality that developers can inherit."""
+class Resource(PermissionedModel):
+    """Simple resource model.
+
+    Will eventually be removed when a more usable resource is added."""
 
     name = models.CharField(max_length=200)
 
-    class Meta:
-        abstract = True
+    def get_nested_objects(self):
+        """Get objects that Resource is nested on, in this case the owner."""
+        return [self.get_owner()]
 
     # Basics
 
@@ -60,28 +63,14 @@ class AbstractResource(PermissionedModel):
         return result
 
 
-class AbstractItem(PermissionedModel):
-    """Abstract item model that developers can inherit from."""
+class Item(PermissionedModel):
+    """Simple item model.
+
+    Will eventually be removed when more usable resource is added."""
 
     name = models.CharField(max_length=200)
-
-    class Meta:
-        abstract = True
+    resource = models.ForeignKey(Resource, on_delete=models.CASCADE)
 
     def get_name(self):
-        """Get name of abstract item."""
+        """Get name of item."""
         return self.name
-
-
-class Resource(AbstractResource):
-    """Non-abstract resource model."""
-
-    def get_nested_objects(self):
-        """Get objects that Resource is nested on, in this case the owner."""
-        return [self.get_owner()]
-
-
-class Item(AbstractItem):
-    """Non-abstract item model."""
-
-    resource = models.ForeignKey(Resource, on_delete=models.CASCADE)

--- a/concord/resources/state_changes.py
+++ b/concord/resources/state_changes.py
@@ -5,7 +5,7 @@ import logging
 from django.core.exceptions import ObjectDoesNotExist
 
 from concord.actions.state_changes import BaseStateChange
-from concord.resources.models import AbstractResource, AbstractItem, Resource, Item, Comment
+from concord.resources.models import Resource, Item, Comment
 
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,7 @@ class ChangeResourceNameStateChange(BaseStateChange):
 
     @classmethod
     def get_settable_classes(cls):
-        return [AbstractResource, AbstractItem, Resource, Item]
+        return [Resource, Item]
 
     def description_present_tense(self):
         return f"change name of resource to {self.new_name}"
@@ -190,7 +190,7 @@ class RemoveItemStateChange(BaseStateChange):
 
     @classmethod
     def get_settable_classes(cls):
-        return [AbstractResource, AbstractItem, Resource, Item]
+        return [Resource, Item]
 
     def description_present_tense(self):
         return f"remove item with pk {self.item_pk}"


### PR DESCRIPTION
Left Item and Resource for now, since we use them in a lot of integration tests. When we've got a more usable resource in core (forum? table?) we'll swap it into the tests and delete Item and Resource too, which are too generaly to be useful.