### PR TITLE
Let AddComment be configured by target_type

### DIFF
--- a/concord/communities/client.py
+++ b/concord/communities/client.py
@@ -7,6 +7,7 @@ from django.db.models import Model
 from django.contrib.auth.models import User
 
 from concord.actions.client import BaseClient
+from concord.actions.utils import Changes
 from concord.actions.text_utils import community_basic_info_to_text, community_governance_info_to_text
 from concord.communities.models import Community
 from concord.communities.customfields import RoleHandler
@@ -89,6 +90,10 @@ class CommunityClient(BaseClient):
         roles = RoleHandler()
         roles.initialize_with_creator(creator=self.actor.pk)
         community = self.community_model.objects.create(name=name, roles=roles)
+        from concord.permission_resources.client import PermissionResourceClient
+        client = PermissionResourceClient(actor=self.actor, target=community)
+        client.add_permission(permission_type=Changes().Resources.AddComment,  # type: ignore[attr-defined]
+                              permission_roles=["members"], permission_configuration={"target_type": "action"})
         return community
 
     # Read methods which require target to be set

--- a/concord/permission_resources/utils.py
+++ b/concord/permission_resources/utils.py
@@ -43,6 +43,7 @@ def check_configuration(action, permission):
     # Then call check_configuration on the state_change, passing in the permission
     # configuration data, and return the result.
     result, message = change_object.check_configuration(action, permission)
+
     if result is False and message:
         action.resolution.add_to_log(message)
     return result

--- a/concord/resources/models.py
+++ b/concord/resources/models.py
@@ -42,6 +42,9 @@ class CommentCatcher(PermissionedModel):
         """Get name of object."""
         return f"Comment catcher for action {self.action}"
 
+    def get_nested_objects(self):
+        return [self.get_owner()]
+
 
 class Resource(PermissionedModel):
     """Simple resource model.

--- a/concord/tests.py
+++ b/concord/tests.py
@@ -810,7 +810,7 @@ class BasicCommunityTest(DataTestCase):
         # can't remove that role
         action, result = self.client.Community.remove_role(role_name="forwards")
         self.assertEquals(action.error_message,
-            "Role cannot be deleted until it is removed from permissions: 1")
+            f"Role cannot be deleted until it is removed from permissions: {permission.pk}")
 
         # remove the permission
         self.client.PermissionResource.set_target(target=permission)
@@ -1000,7 +1000,7 @@ class PermissionResourceUtilsTest(DataTestCase):
             permission_type=Changes().Permissions.AddRoleToPermission,
             permission_actors=[self.users.pinoe.pk]
         )
-        self.assertEquals(len(PermissionsItem.objects.all()), 2)
+        self.assertEquals(len(PermissionsItem.objects.all()), 3)
 
         # call delete_permissions_on_target
         delete_permissions_on_target(community)


### PR DESCRIPTION
Default permission when create community (all members can comment on actions)